### PR TITLE
unnesting ContentSequence from findingsite

### DIFF
--- a/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
+++ b/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
@@ -147,6 +147,6 @@ left join SourceSeriesforsegmentation using (SOPInstanceUID, measurementGroup_nu
 left join SourceInstance using (SOPInstanceUID, measurementGroup_number)
 
 --the bottom three lines are different from measurement groups query
-left join unnest(TrackingIdentifier.cs_l1.ContentSequence) as ContentSequence1
+left join unnest(findingsite.cs_l1.ContentSequence) as ContentSequence1
 left join unnest(ContentSequence1.ConceptNameCodeSequence) as ConceptNameCodeSequence2
 where ContentSequence1.ValueType in ('CODE') and ConceptNameCodeSequence2.CodeValue not in ('121071','G-C0E3') 

--- a/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
+++ b/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
@@ -110,7 +110,7 @@ with temp as (
   )
   -- We only want to include certain SOP Class UIDs
   AND SOPClassUID IN ("1.2.840.10008.5.1.4.1.1.88.11", "1.2.840.10008.5.1.4.1.1.88.22", "1.2.840.10008.5.1.4.1.1.88.33","1.2.840.10008.5.1.4.1.1.88.34","1.2.840.10008.5.1.4.1.1.88.35") 
-and PatientID in ('LUNG1-002')
+--and PatientID in ('LUNG1-002')
   -- We could activate the below line for testing
   -- AND SOPInstanceUID in ('1.2.276.0.7230010.3.1.4.0.11647.1553294587.292373'
 ),


### PR DESCRIPTION
unnesting ContentSequence from findingsite. Deepa mentions the Value.CodeValue and findingsite.codevalue should be the same. Since Quantity and Value are extracted from ContentSequence1, I think this change could fix the issue.