### PR TITLE
revert revisions to the derived views queries

### DIFF
--- a/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/measurement_groups.sql
+++ b/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/measurement_groups.sql
@@ -1,124 +1,215 @@
---creating a temporary table that is flatenned on most columns using left joins and 
---unnesting upto three levels starting with zeroth level
---the temporary table could be very helpful to visualize.
---Once the table is flattened,
---sub tables are created, one for each attribute of interest.
---then they are joined on measurement group numbers and sop instance uid.
-
-
--- Start by creating a temporary table called 'temp'
-with temp as (
-  -- In the SELECT statement, we're choosing which columns to include in the temporary table
+WITH
+  measurementGroups AS (
+  WITH
+    contentSequenceLevel1 AS (
+    WITH
+      structuredReports AS (
+      SELECT
+        PatientID,
+        SOPInstanceUID,
+        SeriesDescription,
+        ContentSequence
+      FROM
+        `{project}.{dataset}.dicom_metadata`
+      WHERE
+        ( SOPClassUID = "1.2.840.10008.5.1.4.1.1.88.11"
+          OR SOPClassUID = "1.2.840.10008.5.1.4.1.1.88.22"
+          OR SOPClassUID = "1.2.840.10008.5.1.4.1.1.88.33"
+          OR SOPClassUID = "1.2.840.10008.5.1.4.1.1.88.34"
+          OR SOPClassUID = "1.2.840.10008.5.1.4.1.1.88.35" )
+        AND ARRAY_LENGTH(ContentTemplateSequence) <> 0
+        AND ContentTemplateSequence [
+      OFFSET
+        (0)].TemplateIdentifier = "1500"
+        AND ContentTemplateSequence [
+      OFFSET
+        (0)].MappingResource = "DCMR" )
+    SELECT
+      PatientID,
+      SOPInstanceUID,
+      SeriesDescription,
+      contentSequence
+    FROM
+      structuredReports
+    CROSS JOIN
+      UNNEST(ContentSequence) AS contentSequence )
   SELECT
-  SOPInstanceUID, 
-  measurementGroup_number, -- Number assigned to a measurement group
-  cs_l2.UID, -- Unique identifier for the content sequence at level 2
-  cs_l2.TextValue, -- Text value associated with the content sequence at level 2
-  PatientID, 
-  SeriesDescription, 
-  SOPClassUID,
-  cts_l0.MappingResource, -- Resource used to map the content template sequence at level 0
-  cts_l0.TemplateIdentifier, -- Unique identifier for the content template sequence at level 0
-  cs_l0.ValueType, -- Type of value associated with the content sequence at level 0
-  cs_l1_cncs.CodeMeaning, -- Code meaning associated with the concept name coding sequence at level 1
-  cs_l2.ValueType, -- Type of value associated with the content sequence at level 2
-  cs_l2_cncs.CodeValue, -- Code value associated with the concept name coding sequence at level 2
-  cs_l2_cncs.CodingSchemeDesignator, -- Coding scheme designator associated with the concept name coding sequence at level 2
-  cs_l2_cncs.CodeMeaning as cm2, -- Code meaning associated with the concept name coding sequence at level 2, with an alias of 'cm2'
-  cs_l2_rss.ReferencedSOPClassUID, -- Unique identifier for the referenced SOP class
-  cs_l2_rss.ReferencedSOPInstanceUID, -- Unique identifier for the referenced SOP instance
-  cs_l2_rss.ReferencedSegmentNumber, -- Number assigned to a referenced segment
-  cs_l2_css, -- concept Code sequence associated with the content sequence at level 2
-  cs_l1 -- Content sequence at level 1
+    PatientID,
+    SOPInstanceUID,
+    SeriesDescription,
+    contentSequence,
+    measurementGroup_number
   FROM
-  `{project}.{dataset}.dicom_metadata` bid -- Data source
-  -- Left join zeroth level of ContentTemplateSequence
-  LEFT JOIN
-  UNNEST(bid.ContentTemplateSequence) cts_l0
-  -- Left join zeroth level of ContentSequence
-  LEFT JOIN
-  UNNEST(bid.ContentSequence) cs_l0
-  -- Unnest content sequence at level 1, with an offset assigned to measurementGroup_number
-  LEFT JOIN
-  unnest(cs_l0.ContentSequence) cs_l1
+    contentSequenceLevel1
+  CROSS JOIN
+    UNNEST (contentSequence.ContentSequence) AS contentSequence
   WITH
   OFFSET
-  AS measurementGroup_number
-  -- Left join ConceptNameCodeSequence at level 1
-  LEFT JOIN
-  unnest(cs_l1.ConceptNameCodeSequence) cs_l1_cncs
-  -- Unnest content sequence at level 2
-  LEFT JOIN
-  unnest(cs_l1.ContentSequence) cs_l2
-  -- Left join ConceptNameCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ConceptNameCodeSequence) cs_l2_cncs
-  -- Left join ReferencedSOPSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ReferencedSOPSequence) cs_l2_rss
-  -- Left join ConceptCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ConceptCodeSequence) cs_l2_css
+    AS measurementGroup_number
   WHERE
-
-  --SeriesDescription in ("BPR landmark annotations") and
-  -- We only want to include records where the TemplateIdentifier is 1500 and MappingResource is DCMR
-  TemplateIdentifier IN ('1500')
-  AND MappingResource IN ('DCMR')
-
-  -- We only want to include CONTAINER value types in the first level of content sequence
-  AND cs_l0.ValueType IN ('CONTAINER')
-
-  -- We only want to include Measurement Group Code Meanings in the second level of content sequence
-  AND cs_l1_cncs.CodeMeaning IN ("Measurement Group")
-
-  -- We want to include certain value types and code values in the third level of content sequence
-  AND (
-    -- Tracking Identifier--TEXT value type with specific Code Value and Coding Scheme Designator
-    (cs_l2.ValueType IN ('TEXT') AND cs_l2_cncs.CodeValue IN ('112039')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Tracking Unique Identifier--UIDREF value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('UIDREF') AND cs_l2_cncs.CodeValue IN ('112040')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM'))  
-    -- Referenced Segment--IMAGE value type with specific Referenced SOP Class UID
-    OR (cs_l2.ValueType IN ('IMAGE') AND  cs_l2_rss.ReferencedSOPClassUID IN ("1.2.840.10008.5.1.4.1.1.66.4"))
-    -- Source series for segmentation--UIDREF value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('UIDREF') AND cs_l2_cncs.CodeValue IN ('121232')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Finding--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('121071')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Finding Site--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('G-C0E3')AND cs_l2_cncs.CodingSchemeDesignator IN ('SRT'))
-    -- Finding Site--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('363698007')AND cs_l2_cncs.CodingSchemeDesignator IN ('SCT'))  
-  )
-  -- We only want to include certain SOP Class UIDs
-  AND SOPClassUID IN ("1.2.840.10008.5.1.4.1.1.88.11", "1.2.840.10008.5.1.4.1.1.88.22", "1.2.840.10008.5.1.4.1.1.88.33","1.2.840.10008.5.1.4.1.1.88.34","1.2.840.10008.5.1.4.1.1.88.35" )
-
-  -- We could activate the below line for testing
-  -- AND SOPInstanceUID in ('1.2.276.0.7230010.3.1.4.0.11647.1553294587.292373'
-),
-finding as (SELECT * from temp where cm2 ='Finding'),
-findingsite as (SELECT * from temp where cm2 ='Finding Site'),
-ReferencedSegment as (SELECT * from temp where cm2 ='Referenced Segment'),
-SourceSeriesforsegmentation as (SELECT * from temp where cm2 ='Source series for segmentation'),
-TrackingIdentifier as (SELECT * from temp where cm2 ='Tracking Identifier'),
-TrackingUniqueIdentifier as  (SELECT * from temp where cm2 ='Tracking Unique Identifier')
-
-Select
-TrackingIdentifier.SOPInstanceUID, 
-TrackingIdentifier.measurementGroup_number,
-TrackingUniqueIdentifier.UID as trackingUniqueIdentifier,
-TrackingIdentifier.TextValue as trackingIdentifier,
-TrackingIdentifier.PatientID,
-TrackingIdentifier.SeriesDescription,
-finding.cs_l2_css as finding,
-findingsite.cs_l2_css as findingSite,
-SourceSeriesforsegmentation.UID as sourceSegmentedSeriesUID,
-ReferencedSegment.ReferencedSOPInstanceUID as segmentationInstanceUID,
-ReferencedSegment.ReferencedSegmentNumber as segmentationSegmentNumber,
-TrackingIdentifier.cs_l1 as contentSequence
-
-from TrackingIdentifier
-join TrackingUniqueIdentifier using (SOPInstanceUID, measurementGroup_number)
-left join finding using (SOPInstanceUID, measurementGroup_number)
-left join findingsite using (SOPInstanceUID, measurementGroup_number)
-left join ReferencedSegment using (SOPInstanceUID, measurementGroup_number)
-left join SourceSeriesforsegmentation using (SOPInstanceUID, measurementGroup_number)
+    contentSequence.ValueType = "CONTAINER"
+    AND contentSequence.ConceptNameCodeSequence [
+  OFFSET
+    (0)].CodeMeaning = "Measurement Group" ),
+  measurementGroups_withTrackingID AS (
+  SELECT
+    SOPInstanceUID,
+    PatientID,
+    SeriesDescription,
+    measurementGroup_number,
+    unnestedContentSequence.TextValue AS trackingIdentifier,
+    measurementGroups.contentSequence
+  FROM
+    measurementGroups
+  CROSS JOIN
+    UNNEST(contentSequence.ContentSequence) AS unnestedContentSequence
+  WHERE
+    unnestedContentSequence.ValueType = "TEXT"
+    AND ( unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodeValue = "112039"
+      AND unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodingSchemeDesignator = "DCM" ) ),
+  measurementGroups_withTrackingUID AS (
+  SELECT
+    SOPInstanceUID,
+    measurementGroup_number,
+    unnestedContentSequence.UID AS trackingUniqueIdentifier
+  FROM
+    measurementGroups
+  CROSS JOIN
+    UNNEST(contentSequence.ContentSequence) AS unnestedContentSequence
+  WHERE
+    unnestedContentSequence.ValueType = "UIDREF"
+    AND ( unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodeValue = "112040"
+      AND unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodingSchemeDesignator = "DCM" ) ),
+  measurementGroups_withSegmentation AS (
+  SELECT
+    SOPInstanceUID,
+    measurementGroup_number,
+    unnestedContentSequence.ReferencedSOPSequence[
+  OFFSET
+    (0)].ReferencedSOPInstanceUID AS segmentationInstanceUID,
+    unnestedContentSequence.ReferencedSOPSequence[
+  OFFSET
+    (0)].ReferencedSegmentNumber AS segmentationSegmentNumber
+  FROM
+    measurementGroups
+  CROSS JOIN
+    UNNEST(contentSequence.ContentSequence) AS unnestedContentSequence
+  WHERE
+    unnestedContentSequence.ValueType = "IMAGE"
+    AND unnestedContentSequence.ReferencedSOPSequence[
+  OFFSET
+    (0)].ReferencedSOPClassUID = "1.2.840.10008.5.1.4.1.1.66.4" ),
+  measurementGroups_withSourceSeries AS (
+  SELECT
+    SOPInstanceUID,
+    measurementGroup_number,
+    unnestedContentSequence.UID AS sourceSegmentedSeriesUID
+  FROM
+    measurementGroups
+  CROSS JOIN
+    UNNEST(contentSequence.ContentSequence) AS unnestedContentSequence
+  WHERE
+    unnestedContentSequence.ValueType = "UIDREF"
+    AND ( unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodeValue = "121232"
+      AND unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodingSchemeDesignator = "DCM" ) ),
+  measurementGroups_withFinding AS (
+  SELECT
+    SOPInstanceUID,
+    measurementGroup_number,
+    unnestedContentSequence.ConceptCodeSequence [
+  OFFSET
+    (0)] AS finding
+  FROM
+    measurementGroups
+  CROSS JOIN
+    UNNEST(contentSequence.ContentSequence) AS unnestedContentSequence
+  WHERE
+    unnestedContentSequence.ValueType = "CODE"
+    AND ( unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodeValue = "121071"
+      AND unnestedContentSequence.ConceptNameCodeSequence [
+    OFFSET
+      (0)].CodingSchemeDesignator = "DCM" ) ),
+  measurementGroups_withFindingSite AS (
+  SELECT
+    SOPInstanceUID,
+    measurementGroup_number,
+    unnestedContentSequence.ConceptCodeSequence [
+  OFFSET
+    (0)] AS findingSite
+  FROM
+    measurementGroups
+  CROSS JOIN
+    UNNEST(contentSequence.ContentSequence) AS unnestedContentSequence
+  WHERE
+    unnestedContentSequence.ValueType = "CODE"
+	  AND ( (unnestedContentSequence.ConceptNameCodeSequence [
+	OFFSET
+	  (0)].CodeValue = "G-C0E3"
+	  AND unnestedContentSequence.ConceptNameCodeSequence [
+	OFFSET
+	  (0)].CodingSchemeDesignator = "SRT" ) OR  
+		   (unnestedContentSequence.ConceptNameCodeSequence [
+	OFFSET
+	  (0)].CodeValue = "363698007"
+	  AND unnestedContentSequence.ConceptNameCodeSequence [
+	OFFSET
+	  (0)].CodingSchemeDesignator = "SCT" ) ) )
+	  
+SELECT
+  mWithUID.SOPInstanceUID,
+  mWithUID.measurementGroup_number,
+  mWithUID.trackingUniqueIdentifier,
+  mWithID.trackingIdentifier,
+  mWithID.PatientID,
+  mWithID.SeriesDescription,
+  mWithFinding.finding,
+  mWithFindingSite.findingSite,
+  mWithSourceSeries.sourceSegmentedSeriesUID,
+  mWithSegmentation.segmentationInstanceUID,
+  mWithSegmentation.segmentationSegmentNumber,
+  mWithID.contentSequence
+FROM
+  measurementGroups_withTrackingUID AS mWithUID
+JOIN
+  measurementGroups_withTrackingID AS mWithID
+  ---
+ON
+  mWithID.SOPInstanceUID = mWithUID.SOPInstanceUID
+  AND mWithID.measurementGroup_number = mWithUID.measurementGroup_number
+JOIN
+  measurementGroups_withFinding AS mWithFinding
+ON
+  mWithID.SOPInstanceUID = mWithFinding.SOPInstanceUID
+  AND mWithID.measurementGroup_number = mWithFinding.measurementGroup_number
+JOIN
+  measurementGroups_withFindingSite AS mWithFindingSite
+ON
+  mWithID.SOPInstanceUID = mWithFindingSite.SOPInstanceUID
+  AND mWithID.measurementGroup_number = mWithFindingSite.measurementGroup_number
+JOIN
+  measurementGroups_withSourceSeries AS mWithSourceSeries
+ON
+  mWithID.SOPInstanceUID = mWithSourceSeries.SOPInstanceUID
+  AND mWithID.measurementGroup_number = mWithSourceSeries.measurementGroup_number
+JOIN
+  measurementGroups_withSegmentation AS mWithSegmentation
+ON
+  mWithID.SOPInstanceUID = mWithSegmentation.SOPInstanceUID
+  AND mWithID.measurementGroup_number = mWithSegmentation.measurementGroup_number
+  ---
+ORDER BY
+  trackingUniqueIdentifier

--- a/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
+++ b/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
@@ -1,160 +1,99 @@
---creating a temporary table that is flatenned on most columns using left joins and 
---unnesting upto three levels starting with zeroth level
---the temporary table could be very helpful to visualize.
---Once the table is flattened,
---sub tables are created, one for each attribute of interest.
---then they are joined on measurement group numbers and sop instance uid.
-
-
--- Start by creating a temporary table called 'temp'
-with temp as (
-  -- In the SELECT statement, we're choosing which columns to include in the temporary table
+WITH
+  contentSequenceLevel3 AS (
   SELECT
-  SOPInstanceUID, 
-  measurementGroup_number, -- Number assigned to a measurement group
-  cs_l2.UID, -- Unique identifier for the content sequence at level 2
-  cs_l2.TextValue, -- Text value associated with the content sequence at level 2
-  PatientID, 
-  SeriesDescription, 
-  SOPClassUID,
-  cts_l0.MappingResource, -- Resource used to map the content template sequence at level 0
-  cts_l0.TemplateIdentifier, -- Unique identifier for the content template sequence at level 0
-  cs_l0.ValueType, -- Type of value associated with the content sequence at level 0
-  cs_l1_cncs.CodeMeaning, -- Code meaning associated with the concept name coding sequence at level 1
-  cs_l2.ValueType, -- Type of value associated with the content sequence at level 2
-  cs_l2_cncs.CodeValue, -- Code value associated with the concept name coding sequence at level 2
-  cs_l2_cncs.CodingSchemeDesignator, -- Coding scheme designator associated with the concept name coding sequence at level 2
-  cs_l2_cncs.CodeMeaning as cm2, -- Code meaning associated with the concept name coding sequence at level 2, with an alias of 'cm2'
-  cs_l2_rss.ReferencedSOPClassUID, -- Unique identifier for the referenced SOP class
-  cs_l2_rss.ReferencedSOPInstanceUID, -- Unique identifier for the referenced SOP instance
-  cs_l2_rss.ReferencedSegmentNumber, -- Number assigned to a referenced segment
-  cs_l2_ccs, -- concept Code sequence associated with the content sequence at level 2
-  cs_l1, -- Content sequence at level 1
-  cs_l3.ValueType, -- Type of value associated with the content sequence at level 3
-  cs_l3_cncs.CodeValue,  -- Code value associated with the concept name coding sequence at level 3
-  cs_l3_cncs.CodingSchemeDesignator,  -- Coding scheme designator associated with the concept name coding sequence at level 3
-  cs_l3_cncs.CodeMeaning as cm3, -- Code meaning associated with the concept name coding sequence at level 3, with an alias of 'cm3'
-  cs_l3_ccs, -- concept Code sequence associated with the content sequence at level 3
-
-  FROM
-  `{project}.{dataset}.dicom_metadata` bid -- Data source
-  -- Left join zeroth level of ContentTemplateSequence
-  LEFT JOIN
-  UNNEST(bid.ContentTemplateSequence) cts_l0
-  -- Left join zeroth level of ContentSequence
-  LEFT JOIN
-  UNNEST(bid.ContentSequence) cs_l0
-  -- Unnest content sequence at level 1, with an offset assigned to measurementGroup_number
-  LEFT JOIN
-  unnest(cs_l0.ContentSequence) cs_l1
-  WITH
+    PatientID,
+    SOPInstanceUID,
+    measurementGroup_number,
+    segmentationInstanceUID,
+    segmentationSegmentNumber,
+    sourceSegmentedSeriesUID,
+    trackingIdentifier,
+    trackingUniqueIdentifier,
+    contentSequence.ConceptNameCodeSequence [
   OFFSET
-  AS measurementGroup_number
-  -- Left join ConceptNameCodeSequence at level 1
-  LEFT JOIN
-  unnest(cs_l1.ConceptNameCodeSequence) cs_l1_cncs
-  -- Unnest content sequence at level 2
-  LEFT JOIN
-  unnest(cs_l1.ContentSequence) cs_l2
-  -- Left join ConceptNameCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ConceptNameCodeSequence) cs_l2_cncs
-  -- Left join ReferencedSOPSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ReferencedSOPSequence) cs_l2_rss
-  -- Left join ConceptCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ConceptCodeSequence) cs_l2_ccs
-  -- Unnest content sequence at level 3
-  LEFT JOIN
-  unnest(cs_l2.ContentSequence) cs_l3
-  -- Left join ConceptNameCodeSequence at level 3
-  LEFT JOIN
-  unnest(cs_l3.ConceptNameCodeSequence) cs_l3_cncs
-  -- Left join ConceptCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l3.ConceptCodeSequence) cs_l3_ccs
-  
+    (0)] AS ConceptNameCodeSequence,
+    contentSequence.ConceptCodeSequence [
+  OFFSET
+    (0)] AS ConceptCodeSequence
+  FROM
+    `{project}.{dataset}.measurement_groups`
+  CROSS JOIN
+    UNNEST (contentSequence.ContentSequence) AS contentSequence
   WHERE
-  --SeriesDescription in ("BPR landmark annotations", "BPR region annotations") and
-
-  -- We only want to include records where the TemplateIdentifier is 1500 and MappingResource is DCMR
-  TemplateIdentifier IN ('1500')
-  AND MappingResource IN ('DCMR')
-
-  -- We only want to include CONTAINER value types in the first level of content sequence
-  AND cs_l0.ValueType IN ('CONTAINER')
-
-  -- We only want to include Measurement Group Code Meanings in the second level of content sequence
-  AND cs_l1_cncs.CodeMeaning IN ("Measurement Group")
-
-  -- We want to include certain value types and code values in the third level of content sequence
-  AND (
-    -- Tracking Identifier-- TEXT value type with specific Code Value and Coding Scheme Designator
-    (cs_l2.ValueType IN ('TEXT') AND cs_l2_cncs.CodeValue IN ('112039')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Tracking Unique Identifier--UIDREF value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('UIDREF') AND cs_l2_cncs.CodeValue IN ('112040')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM'))  
-    -- Referenced Segment or Source--IMAGE value type with specific Referenced SOP Class UID
-    OR (cs_l2.ValueType IN ('IMAGE') AND  cs_l2_rss.ReferencedSOPClassUID IN ("1.2.840.10008.5.1.4.1.1.66.4","1.2.840.10008.5.1.4.1.1.2"))--allowing one more class for 'Source'
-    -- Source series for segmentation--UIDREF value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('UIDREF') AND cs_l2_cncs.CodeValue IN ('121232')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Finding--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('121071')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Finding Site--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('G-C0E3')AND cs_l2_cncs.CodingSchemeDesignator IN ('SRT'))
-    -- Finding Site--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('363698007')AND cs_l2_cncs.CodingSchemeDesignator IN ('SCT'))  
-  )
-  -- We only want to include certain SOP Class UIDs
-  AND SOPClassUID IN ("1.2.840.10008.5.1.4.1.1.88.11", "1.2.840.10008.5.1.4.1.1.88.22", "1.2.840.10008.5.1.4.1.1.88.33","1.2.840.10008.5.1.4.1.1.88.34","1.2.840.10008.5.1.4.1.1.88.35") 
-
-  -- We could activate the below line for testing
-  -- AND SOPInstanceUID in ('1.2.276.0.7230010.3.1.4.0.11647.1553294587.292373'
-),
-finding as (SELECT * from temp where cm2 ='Finding'),
-findingsite as (SELECT * from temp where cm2 ='Finding Site'),
-ReferencedSegment as (SELECT * from temp where cm2 ='Referenced Segment'),
-SourceSeriesforsegmentation as (SELECT * from temp where cm2 ='Source series for segmentation'),
-TrackingIdentifier as (SELECT * from temp where cm2 ='Tracking Identifier'),
-TrackingUniqueIdentifier as  (SELECT * from temp where cm2 ='Tracking Unique Identifier'),
-SourceInstance as  (SELECT * from temp where cm2 ='Source')
-
-Select
-TrackingIdentifier.SOPInstanceUID, 
-TrackingIdentifier.measurementGroup_number,
-TrackingUniqueIdentifier.UID as trackingUniqueIdentifier,
-TrackingIdentifier.TextValue as trackingIdentifier,
-TrackingIdentifier.PatientID,
---TrackingIdentifier.SeriesDescription,  --different from measurement groups query
-SourceSeriesforsegmentation.UID as sourceSegmentedSeriesUID,
-SourceInstance.ReferencedSOPInstanceUID as sourceReferencedSOPInstanceUID,--newly introduced column compared to previous qualitative query
-ReferencedSegment.ReferencedSOPInstanceUID as segmentationInstanceUID,
-ReferencedSegment.ReferencedSegmentNumber as segmentationSegmentNumber,
-ContentSequence1.ConceptNameCodeSequence[SAFE_OFFSET(0)] as Quantity, --different from measurements groups query
-ContentSequence1.ConceptCodeSequence[SAFE_OFFSET(0)] as Value,--different from measurements groups query
-finding.cs_l2_ccs as finding,
-findingsite.cs_l2_ccs as findingSite,
-findingsite.cs_l3_ccs as findingSite_topographicalModifier--newly introduced array compared to previous qualitative query
-
---TrackingIdentifier.cs_l1 as contentSequence --different from measurements groups query
-
-from TrackingIdentifier
-join TrackingUniqueIdentifier using (SOPInstanceUID, measurementGroup_number)
-left join finding using (SOPInstanceUID, measurementGroup_number)
-left join findingsite using (SOPInstanceUID, measurementGroup_number)
-left join ReferencedSegment using (SOPInstanceUID, measurementGroup_number)
-left join SourceSeriesforsegmentation using (SOPInstanceUID, measurementGroup_number)
-left join SourceInstance using (SOPInstanceUID, measurementGroup_number)
-
---the bottom three lines are different from measurement groups query
-left join unnest(TrackingIdentifier.cs_l1.ContentSequence) as ContentSequence1
-left join unnest(ContentSequence1.ConceptNameCodeSequence) as ConceptNameCodeSequence2
--- 
-where ContentSequence1.ValueType in ('CODE') 
-  # the following conditions are not excluded, since for the annotations in the nnU-Net-BPR-annotations the only kind of assessment is 
-  # stored for the SCT Finding Site code
-  # and not (ConceptNameCodeSequence2.CodeValue = '121071' and ConceptNameCodeSequence2.CodingSchemeDesignator = "DCM") -- DCM Finding
-  # and not (ConceptNameCodeSequence2.CodeValue = 'G-C0E3' and ConceptNameCodeSequence2.CodingSchemeDesignator = "SRT") -- SRT Finding Site
-  # and not (ConceptNameCodeSequence2.CodeValue = '363698007' and ConceptNameCodeSequence2.CodingSchemeDesignator = "SCT") -- SCT Finding Site
-# test subjects from LIDC and NLST collections
-#and TrackingIdentifier.PatientID = "LIDC-IDRI-0001" # "100012" 
+    contentSequence.ValueType = "CODE" ),
+  findingsAndFindingSites AS (
+  WITH
+    findings AS (
+    SELECT
+      PatientID,
+      SOPInstanceUID,
+      measurementGroup_number,
+      segmentationInstanceUID,
+      segmentationSegmentNumber,
+      sourceSegmentedSeriesUID,
+      trackingIdentifier,
+      trackingUniqueIdentifier,
+      ConceptCodeSequence AS finding
+    FROM
+      contentSequenceLevel3
+    WHERE
+      ConceptNameCodeSequence.CodeValue = "121071"
+      AND ConceptNameCodeSequence.CodingSchemeDesignator = "DCM" ),
+    findingSites AS (
+    SELECT
+      PatientID,
+      SOPInstanceUID,
+      measurementGroup_number,
+      ConceptCodeSequence AS findingSite
+    FROM
+      contentSequenceLevel3
+    WHERE
+      ConceptNameCodeSequence.CodeValue = "G-C0E3"
+      AND ConceptNameCodeSequence.CodingSchemeDesignator = "SRT" )
+  SELECT
+    findings.PatientID,
+    findings.SOPInstanceUID,
+    findings.finding,
+    findings.segmentationInstanceUID,
+    findings.segmentationSegmentNumber,
+    findings.sourceSegmentedSeriesUID,
+    findings.trackingIdentifier,
+    findings.trackingUniqueIdentifier,
+    findingSites.findingSite,
+    findingSites.measurementGroup_number
+  FROM
+    findings
+  JOIN
+    findingSites
+  ON
+    findings.SOPInstanceUID = findingSites.SOPInstanceUID
+    AND findings.measurementGroup_number = findingSites.measurementGroup_number )
+SELECT
+  contentSequenceLevel3.PatientID,
+  contentSequenceLevel3.SOPInstanceUID,
+  findingsAndFindingSites.measurementGroup_number,
+  findingsAndFindingSites.segmentationInstanceUID,
+  findingsAndFindingSites.segmentationSegmentNumber,
+  findingsAndFindingSites.sourceSegmentedSeriesUID,
+  findingsAndFindingSites.trackingIdentifier,
+  findingsAndFindingSites.trackingUniqueIdentifier,
+  contentSequenceLevel3.ConceptNameCodeSequence AS Quantity,
+  contentSequenceLevel3.ConceptCodeSequence AS Value,
+  findingsAndFindingSites.finding,
+  findingsAndFindingSites.findingSite
+FROM
+  contentSequenceLevel3
+JOIN
+  findingsAndFindingSites
+ON
+  contentSequenceLevel3.SOPInstanceUID = findingsAndFindingSites.SOPInstanceUID
+  AND contentSequenceLevel3.measurementGroup_number = findingsAndFindingSites.measurementGroup_number
+WHERE
+  # exclude
+  ( ConceptNameCodeSequence.CodeMeaning <> "121071"
+    AND ConceptNameCodeSequence.CodingSchemeDesignator <> "DCM" ) AND # Finding
+  ( ConceptNameCodeSequence.CodeMeaning <> "G-C0E3"
+    AND ConceptNameCodeSequence.CodingSchemeDesignator <> "SRT" ) # Finding Site
+  # correctness check: adding the below should result in a 36 rows column (4 segmented lesions, with 9 evaluations per each)
+  #    AND
+  #  contentSequenceLevel3.PatientID = "LIDC-IDRI-0001"

--- a/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/quantitative_measurements.sql
+++ b/bq/derived_table_creation/BQ_Table_Building/derived_data_views/sql/quantitative_measurements.sql
@@ -1,139 +1,185 @@
---creating a temporary table that is flatenned on most columns using left joins and 
---unnesting upto three levels starting with zeroth level
---the temporary table could be very helpful to visualize.
---Once the table is flattened,
---sub tables are created, one for each attribute of interest.
---then they are joined on measurement group numbers and sop instance uid.
-
-
--- Start by creating a temporary table called 'temp'
-with temp as (
-  -- In the SELECT statement, we're choosing which columns to include in the temporary table
+WITH
+  ---
+  contentSequenceLevel3numeric AS (
   SELECT
-  SOPInstanceUID, 
-  measurementGroup_number, -- Number assigned to a measurement group
-  cs_l2.UID, -- Unique identifier for the content sequence at level 2
-  cs_l2.TextValue, -- Text value associated with the content sequence at level 2
-  PatientID, 
-  SeriesDescription, 
-  SOPClassUID,
-  cts_l0.MappingResource, -- Resource used to map the content template sequence at level 0
-  cts_l0.TemplateIdentifier, -- Unique identifier for the content template sequence at level 0
-  cs_l0.ValueType, -- Type of value associated with the content sequence at level 0
-  cs_l1_cncs.CodeMeaning, -- Code meaning associated with the concept name coding sequence at level 1
-  cs_l2.ValueType, -- Type of value associated with the content sequence at level 2
-  cs_l2_cncs.CodeValue, -- Code value associated with the concept name coding sequence at level 2
-  cs_l2_cncs.CodingSchemeDesignator, -- Coding scheme designator associated with the concept name coding sequence at level 2
-  cs_l2_cncs.CodeMeaning as cm2, -- Code meaning associated with the concept name coding sequence at level 2, with an alias of 'cm2'
-  cs_l2_rss.ReferencedSOPClassUID, -- Unique identifier for the referenced SOP class
-  cs_l2_rss.ReferencedSOPInstanceUID, -- Unique identifier for the referenced SOP instance
-  cs_l2_rss.ReferencedSegmentNumber, -- Number assigned to a referenced segment
-  cs_l2_ccs, -- concept Code sequence associated with the content sequence at level 2
-  cs_l1 -- Content sequence at level 1
+    PatientID,
+    SOPInstanceUID,
+	SeriesDescription,
+    measurementGroup_number,
+    segmentationInstanceUID,
+    segmentationSegmentNumber,
+    sourceSegmentedSeriesUID,
+    trackingIdentifier,
+    trackingUniqueIdentifier,
+    contentSequence.ConceptNameCodeSequence [
+  SAFE_OFFSET
+    (0)] AS ConceptNameCodeSequence,
+    contentSequence.MeasuredValueSequence [
+  SAFE_OFFSET
+    (0)] AS MeasuredValueSequence,
+    contentSequence.MeasuredValueSequence [
+  SAFE_OFFSET
+    (0)].MeasurementUnitsCodeSequence [
+  SAFE_OFFSET
+    (0)] AS MeasurementUnits,
+    contentSequence.ContentSequence
   FROM
-  `{project}.{dataset}.dicom_metadata` bid -- Data source
-  -- Left join zeroth level of ContentTemplateSequence
-  LEFT JOIN
-  UNNEST(bid.ContentTemplateSequence) cts_l0
-  -- Left join zeroth level of ContentSequence
-  LEFT JOIN
-  UNNEST(bid.ContentSequence) cs_l0
-  -- Unnest content sequence at level 1, with an offset assigned to measurementGroup_number
-  LEFT JOIN
-  unnest(cs_l0.ContentSequence) cs_l1
-  WITH
-  OFFSET
-  AS measurementGroup_number
-  -- Left join ConceptNameCodeSequence at level 1
-  LEFT JOIN
-  unnest(cs_l1.ConceptNameCodeSequence) cs_l1_cncs
-  -- Unnest content sequence at level 2
-  LEFT JOIN
-  unnest(cs_l1.ContentSequence) cs_l2
-  -- Left join ConceptNameCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ConceptNameCodeSequence) cs_l2_cncs
-  -- Left join ReferencedSOPSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ReferencedSOPSequence) cs_l2_rss
-  -- Left join ConceptCodeSequence at level 2
-  LEFT JOIN
-  unnest(cs_l2.ConceptCodeSequence) cs_l2_ccs
+    `{project}.{dataset}.measurement_groups`
+  CROSS JOIN
+    UNNEST (contentSequence.ContentSequence) AS contentSequence
   WHERE
-  --SeriesDescription in ("BPR landmark annotations") and
-  -- We only want to include records where the TemplateIdentifier is 1500 and MappingResource is DCMR
-  TemplateIdentifier IN ('1500')
-  AND MappingResource IN ('DCMR')
-
-  -- We only want to include CONTAINER value types in the first level of content sequence
-  AND cs_l0.ValueType IN ('CONTAINER')
-
-  -- We only want to include Measurement Group Code Meanings in the second level of content sequence
-  AND cs_l1_cncs.CodeMeaning IN ("Measurement Group")
-
-  -- We want to include certain value types and code values in the third level of content sequence
-  AND (
-    -- Tracking Identifier-- TEXT value type with specific Code Value and Coding Scheme Designator
-    (cs_l2.ValueType IN ('TEXT') AND cs_l2_cncs.CodeValue IN ('112039')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Tracking Unique Identifier-- UIDREF value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('UIDREF') AND cs_l2_cncs.CodeValue IN ('112040')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM'))  
-    -- Referenced Segment or Source--IMAGE value type with specific Referenced SOP Class UID
-    OR (cs_l2.ValueType IN ('IMAGE') AND  cs_l2_rss.ReferencedSOPClassUID IN ("1.2.840.10008.5.1.4.1.1.66.4")) --not included the code for 'Source' as it is not necessary 
-    -- Source series for segmentation--UIDREF value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('UIDREF') AND cs_l2_cncs.CodeValue IN ('121232')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Finding--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('121071')AND cs_l2_cncs.CodingSchemeDesignator IN ('DCM')) 
-    -- Finding Site--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('G-C0E3')AND cs_l2_cncs.CodingSchemeDesignator IN ('SRT'))
-    -- Finding Site--CODE value type with specific Code Value and Coding Scheme Designator
-    OR (cs_l2.ValueType IN ('CODE') AND cs_l2_cncs.CodeValue IN ('363698007')AND cs_l2_cncs.CodingSchemeDesignator IN ('SCT'))  
-  )
-  -- We only want to include certain SOP Class UIDs
-  AND SOPClassUID IN ("1.2.840.10008.5.1.4.1.1.88.11", "1.2.840.10008.5.1.4.1.1.88.22", "1.2.840.10008.5.1.4.1.1.88.33","1.2.840.10008.5.1.4.1.1.88.34","1.2.840.10008.5.1.4.1.1.88.35" )
-
-  -- We could activate the below line for testing
-  --AND SOPInstanceUID in ('1.2.276.0.7230010.3.1.4.0.11647.1553294587.292373')
-
-),
-finding as (SELECT * from temp where cm2 ='Finding'),
-findingsite as (SELECT * from temp where cm2 ='Finding Site'),
-ReferencedSegment as (SELECT * from temp where cm2 ='Referenced Segment'),
-SourceSeriesforsegmentation as (SELECT * from temp where cm2 ='Source series for segmentation'),
-TrackingIdentifier as (SELECT * from temp where cm2 ='Tracking Identifier'),
-TrackingUniqueIdentifier as  (SELECT * from temp where cm2 ='Tracking Unique Identifier')
-
-Select
-TrackingIdentifier.SOPInstanceUID, 
-TrackingIdentifier.measurementGroup_number,
-TrackingUniqueIdentifier.UID as trackingUniqueIdentifier,
-TrackingIdentifier.TextValue as trackingIdentifier,
-TrackingIdentifier.PatientID,
-TrackingIdentifier.SeriesDescription, 
-
-SourceSeriesforsegmentation.UID as sourceSegmentedSeriesUID,
-ReferencedSegment.ReferencedSOPInstanceUID as segmentationInstanceUID,
-ReferencedSegment.ReferencedSegmentNumber as segmentationSegmentNumber,
-
-ContentSequence1.ConceptNameCodeSequence[SAFE_OFFSET(0)] as Quantity, --different from measurement groups query
-ContentSequence1.ConceptCodeSequence[SAFE_OFFSET(0)] as derivationModifier,--different from measurement groups query and qualitative measurements
-(SAFE_CAST((MeasuredValueSequence.NumericValue[SAFE_OFFSET(0)]) AS NUMERIC )) AS Value,--different from measurement groups query and qualitative measurements
-MeasurementUnitsCodeSequence AS Units,--different from measurement groups query and qualitative measurements
-
-finding.cs_l2_ccs as finding,
-findingsite.cs_l2_ccs as findingSite,
-
-from TrackingIdentifier
-join TrackingUniqueIdentifier using (SOPInstanceUID, measurementGroup_number)
-left join finding using (SOPInstanceUID, measurementGroup_number)
-left join findingsite using (SOPInstanceUID, measurementGroup_number)
-left join ReferencedSegment using (SOPInstanceUID, measurementGroup_number)
-left join SourceSeriesforsegmentation using (SOPInstanceUID, measurementGroup_number)
---the next two lines are different from measurements query and the next two lines are different from qualitative measurements query
-left join unnest(TrackingIdentifier.cs_l1.ContentSequence) as ContentSequence1
-left join unnest(ContentSequence1.ConceptNameCodeSequence) as ConceptNameCodeSequence2
-left join unnest(ContentSequence1.MeasuredValueSequence) as MeasuredValueSequence
-left join unnest(MeasuredValueSequence.MeasurementUnitsCodeSequence) as MeasurementUnitsCodeSequence
---the filter applied is changed from CODE in qualitative measurements query to NUM in the quantitative query
-where ContentSequence1.ValueType in ('NUM') 
---and finding.PatientID in ("LIDC-IDRI-0001") -- LIDC test patient
---and finding.PatientID in ("100012") -- NLST test patient
+    contentSequence.ValueType = "NUM" ),
+  ---
+  contentSequenceLevel3codes AS (
+  SELECT
+    PatientID,
+    SOPInstanceUID,
+	SeriesDescription,
+    measurementGroup_number,
+    segmentationInstanceUID,
+    segmentationSegmentNumber,
+    sourceSegmentedSeriesUID,
+    trackingIdentifier,
+    trackingUniqueIdentifier,
+    contentSequence.ConceptNameCodeSequence [
+  SAFE_OFFSET
+    (0)] AS ConceptNameCodeSequence,
+    contentSequence.ConceptCodeSequence [
+  SAFE_OFFSET
+    (0)] AS ConceptCodeSequence
+  FROM
+    `{project}.{dataset}.measurement_groups`
+  CROSS JOIN
+    UNNEST (contentSequence.ContentSequence) AS contentSequence
+  WHERE
+    contentSequence.ValueType = "CODE" ),
+  ---
+  contentSequenceLevel3uidrefs AS (
+  SELECT
+    contentSequence.ConceptNameCodeSequence [
+  SAFE_OFFSET
+    (0)] AS ConceptNameCodeSequence,
+    contentSequence.ConceptCodeSequence [
+  SAFE_OFFSET
+    (0)] AS ConceptCodeSequence,
+    measurementGroup_number
+  FROM
+    `{project}.{dataset}.measurement_groups`
+  CROSS JOIN
+    UNNEST (contentSequence.ContentSequence) AS contentSequence
+  WHERE
+    contentSequence.ValueType = "UIDREF"
+    AND ConceptCodeSequence [
+  SAFE_OFFSET
+    (0)].CodeMeaning = "Tracking Unique Identifier" ),
+  ---
+  findings AS (
+  SELECT
+    PatientID,
+    SOPInstanceUID,
+	SeriesDescription,
+    ConceptCodeSequence AS finding,
+    measurementGroup_number,
+    segmentationInstanceUID,
+    segmentationSegmentNumber,
+    sourceSegmentedSeriesUID,
+    trackingIdentifier,
+    trackingUniqueIdentifier,
+  FROM
+    contentSequenceLevel3codes
+  WHERE
+    ConceptNameCodeSequence.CodeValue = "121071"
+    AND ConceptNameCodeSequence.CodingSchemeDesignator = "DCM" ),
+  ---
+  findingSites AS (
+  SELECT
+    PatientID,
+    SOPInstanceUID,
+	SeriesDescription,
+    ConceptCodeSequence AS findingSite,
+    measurementGroup_number
+  FROM
+    contentSequenceLevel3codes
+  WHERE
+    (ConceptNameCodeSequence.CodeValue = "G-C0E3"
+    AND ConceptNameCodeSequence.CodingSchemeDesignator = "SRT" ) OR 
+    (ConceptNameCodeSequence.CodeValue = "363698007"
+    AND ConceptNameCodeSequence.CodingSchemeDesignator = "SCT" ) ), 
+  ---
+  findingsAndFindingSites AS (
+  SELECT
+    findings.PatientID,
+    findings.SOPInstanceUID,
+	findings.SeriesDescription,
+    findings.finding,
+    findingSites.findingSite,
+    findingSites.measurementGroup_number,
+    findings.segmentationInstanceUID,
+    findings.segmentationSegmentNumber,
+    findings.sourceSegmentedSeriesUID,
+    findings.trackingIdentifier,
+    findings.trackingUniqueIdentifier
+  FROM
+    findings
+  JOIN
+    findingSites
+  ON
+    findings.SOPInstanceUID = findingSites.SOPInstanceUID
+    AND findings.measurementGroup_number = findingSites.measurementGroup_number ) ---
+  # correctness check: the below should result in 11 rows (this is how many segments/measurement
+    # groups are there for each QIN-HEADNCK-01-0139 segmentation
+    #SELECT
+    #  *
+    #FROM
+    #  findingsAndFindingSites
+    #WHERE
+    #  SOPInstanceUID = "1.2.276.0.7230010.3.1.4.8323329.18336.1440004659.731760"
+    ---
+  SELECT
+    contentSequenceLevel3numeric.PatientID,
+    contentSequenceLevel3numeric.SOPInstanceUID,
+	contentSequenceLevel3numeric.SeriesDescription,
+    contentSequenceLevel3numeric.measurementGroup_number,
+    findingsAndFindingSites.segmentationInstanceUID,
+    findingsAndFindingSites.segmentationSegmentNumber,
+    findingsAndFindingSites.sourceSegmentedSeriesUID,
+    findingsAndFindingSites.trackingIdentifier,
+    findingsAndFindingSites.trackingUniqueIdentifier,
+    contentSequenceLevel3numeric.ConceptNameCodeSequence AS Quantity,
+    CASE ( ARRAY_LENGTH(contentSequenceLevel3numeric.ContentSequence) > 0
+      AND contentSequenceLevel3numeric.ContentSequence [
+    SAFE_OFFSET
+      (0)].ConceptNameCodeSequence [
+    SAFE_OFFSET
+      (0)].CodeValue = "121401"
+      AND contentSequenceLevel3numeric.ContentSequence [
+    SAFE_OFFSET
+      (0)].ConceptNameCodeSequence [
+    SAFE_OFFSET
+      (0)].CodingSchemeDesignator = "DCM" )
+      WHEN TRUE THEN STRUCT( contentSequenceLevel3numeric.ContentSequence [ SAFE_OFFSET (0)].ConceptCodeSequence [ SAFE_OFFSET (0)].CodeValue AS CodeValue, contentSequenceLevel3numeric.ContentSequence [ SAFE_OFFSET (0)].ConceptCodeSequence [ SAFE_OFFSET (0)].CodingSchemeDesignator AS CodingSchemeDesignator, contentSequenceLevel3numeric.ContentSequence [ SAFE_OFFSET (0)].ConceptCodeSequence [ SAFE_OFFSET (0)].CodeMeaning AS CodeMeaning )
+    ELSE
+    STRUCT(NULL as CodeValue,NULL as CodingSchemeDesignator,NULL as CodeMeaning)
+  END
+    AS derivationModifier,
+    SAFE_CAST( contentSequenceLevel3numeric.MeasuredValueSequence.NumericValue [
+    SAFE_OFFSET
+      (0)] AS NUMERIC ) AS Value,
+    contentSequenceLevel3numeric.MeasurementUnits AS Units,
+    findingsAndFindingSites.finding,
+    findingsAndFindingSites.findingSite
+  FROM
+    contentSequenceLevel3numeric
+  JOIN
+    findingsAndFindingSites
+  ON
+    contentSequenceLevel3numeric.SOPInstanceUID = findingsAndFindingSites.SOPInstanceUID
+    AND contentSequenceLevel3numeric.measurementGroup_number = findingsAndFindingSites.measurementGroup_number ---
+    # correctness check: for this patient, there should be 12 rows: 4 segmented nodules, with 3 numeric evaluations for each
+    #WHERE
+    #  contentSequenceLevel3numeric.PatientID = "LIDC-IDRI-0001"
+    ---
+    # correctness check: for this specific instance, there should be 238 rows (11 segments)
+    #WHERE
+    #  contentSequenceLevel3numeric.SOPInstanceUID = "1.2.276.0.7230010.3.1.4.8323329.18336.1440004659.731760"
+    #where contentSequenceLevel3numeric.PatientID LIKE "%QIN%"


### PR DESCRIPTION
This reverts changes introduced in https://github.com/ImagingDataCommons/etl_flow/pull/64 and following PRs.

Following the investigation of the issues identified in https://github.com/ImagingDataCommons/etl_flow/issues/70, I decided not to hold the release of v13 any longer. These revisions will require more work and time.