### PR TITLE
add SeriesInstanceUID to the SR-derived measurement tables

### DIFF
--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/measurement_groups.json
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/measurement_groups.json
@@ -16,6 +16,12 @@
       {
         "description": "TBD",
         "mode": "NULLABLE",
+        "name": "SeriesInstanceUID",
+        "type": "STRING"
+      },
+      {
+        "description": "TBD",
+        "mode": "NULLABLE",
         "name": "measurementGroup_number",
         "type": "INTEGER"
       },

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/qualitative_measurements.json
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/qualitative_measurements.json
@@ -8,15 +8,27 @@
   "schema": {
     "fields": [
       {
-        "description": "TBD",
+        "description": "PatientID of the patient from the Structured Report that was used to extract the measurement",
         "mode": "NULLABLE",
         "name": "PatientID",
         "type": "STRING"
       },
       {
-        "description": "TBD",
+        "description": "SOPInstanceUID of the Structured Report that was used to extract the measurement",  
         "mode": "NULLABLE",
         "name": "SOPInstanceUID",
+        "type": "STRING"
+      },
+      {
+        "description": "SeriesInstanceUID of the Structured Report that was used to extract the measurement",  
+        "mode": "NULLABLE",
+        "name": "SeriesInstanceUID",
+        "type": "STRING"
+      },
+      {
+        "description": "SeriesDescription of the Structured Report that was used to extract the measurement",  
+        "mode": "NULLABLE",
+        "name": "SeriesDescription",
         "type": "STRING"
       },
       {

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/quantitative_measurements.json
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/quantitative_measurements.json
@@ -8,15 +8,27 @@
   "schema": {
     "fields": [
       {
-        "description": "TBD",
+        "description": "PatientID of the patient from the Structured Report that was used to extract the measurement",
         "mode": "NULLABLE",
         "name": "PatientID",
         "type": "STRING"
       },
       {
-        "description": "TBD",
+        "description": "SOPInstanceUID of the Structured Report that was used to extract the measurement",  
         "mode": "NULLABLE",
         "name": "SOPInstanceUID",
+        "type": "STRING"
+      },
+      {
+        "description": "SeriesInstanceUID of the Structured Report that was used to extract the measurement",  
+        "mode": "NULLABLE",
+        "name": "SeriesInstanceUID",
+        "type": "STRING"
+      },
+      {
+        "description": "SeriesDescription of the Structured Report that was used to extract the measurement",  
+        "mode": "NULLABLE",
+        "name": "SeriesDescription",
         "type": "STRING"
       },
       {

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/measurement_groups.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/measurement_groups.sql
@@ -7,6 +7,7 @@ WITH
       SELECT
         PatientID,
         SOPInstanceUID,
+        SeriesInstanceUID,
         SeriesDescription,
         ContentSequence
       FROM
@@ -27,6 +28,7 @@ WITH
     SELECT
       PatientID,
       SOPInstanceUID,
+      SeriesInstanceUID,
       SeriesDescription,
       contentSequence
     FROM
@@ -36,6 +38,7 @@ WITH
   SELECT
     PatientID,
     SOPInstanceUID,
+    SeriesInstanceUID,
     SeriesDescription,
     contentSequence,
     measurementGroup_number
@@ -55,6 +58,7 @@ WITH
   SELECT
     SOPInstanceUID,
     PatientID,
+    SeriesInstanceUID,
     SeriesDescription,
     measurementGroup_number,
     unnestedContentSequence.TextValue AS trackingIdentifier,
@@ -74,6 +78,7 @@ WITH
   measurementGroups_withTrackingUID AS (
   SELECT
     SOPInstanceUID,
+    SeriesInstanceUID,
     measurementGroup_number,
     unnestedContentSequence.UID AS trackingUniqueIdentifier
   FROM
@@ -171,6 +176,7 @@ WITH
 	  
 SELECT
   mWithUID.SOPInstanceUID,
+  mWithUID.SeriesInstanceUID,
   mWithUID.measurementGroup_number,
   mWithUID.trackingUniqueIdentifier,
   mWithID.trackingIdentifier,

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
@@ -3,6 +3,7 @@ WITH
   SELECT
     PatientID,
     SOPInstanceUID,
+    SeriesInstanceUID,
     measurementGroup_number,
     segmentationInstanceUID,
     segmentationSegmentNumber,
@@ -71,6 +72,7 @@ WITH
 SELECT
   contentSequenceLevel3.PatientID,
   contentSequenceLevel3.SOPInstanceUID,
+  contentSequenceLevel3.SeriesInstanceUID,
   findingsAndFindingSites.measurementGroup_number,
   findingsAndFindingSites.segmentationInstanceUID,
   findingsAndFindingSites.segmentationSegmentNumber,

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/quantitative_measurements.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/quantitative_measurements.sql
@@ -4,7 +4,8 @@ WITH
   SELECT
     PatientID,
     SOPInstanceUID,
-	SeriesDescription,
+    SeriesInstanceUID,
+	  SeriesDescription,
     measurementGroup_number,
     segmentationInstanceUID,
     segmentationSegmentNumber,
@@ -34,7 +35,7 @@ WITH
   SELECT
     PatientID,
     SOPInstanceUID,
-	SeriesDescription,
+	  SeriesDescription,
     measurementGroup_number,
     segmentationInstanceUID,
     segmentationSegmentNumber,
@@ -119,7 +120,7 @@ WITH
   SELECT
     findings.PatientID,
     findings.SOPInstanceUID,
-	findings.SeriesDescription,
+	  findings.SeriesDescription,
     findings.finding,
     findingSites.findingSite,
     findingSites.lateralityModifier,
@@ -148,7 +149,8 @@ WITH
   SELECT
     contentSequenceLevel3numeric.PatientID,
     contentSequenceLevel3numeric.SOPInstanceUID,
-	contentSequenceLevel3numeric.SeriesDescription,
+    contentSequenceLevel3numeric.SeriesInstanceUID,
+	  contentSequenceLevel3numeric.SeriesDescription,
     contentSequenceLevel3numeric.measurementGroup_number,
     findingsAndFindingSites.segmentationInstanceUID,
     findingsAndFindingSites.segmentationSegmentNumber,


### PR DESCRIPTION
Since files are organized in the buckets by series, and SOPInstanceUID is not included in idc-index, adding this attribute makes it easier to use the measurements tables