### PR TITLE
ENH: add SeriesInstanceUID for measurements

### DIFF
--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/qualitative_measurements.json
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/qualitative_measurements.json
@@ -39,6 +39,12 @@
         "type": "STRING"
       },
       {
+        "description": "SeriesInstanceUID of the segmentation object defining the region of interest corresponding to the measurement.",
+        "mode": "NULLABLE",
+        "name": "segmentationSeriesUID",
+        "type": "STRING"
+      },
+      {
         "description": "SegmentNumber of the segment within the segmentation object referenced by segmentationInstanceUID defining the region of interest corresponding to the measurement.",
         "mode": "REPEATED",
         "name": "segmentationSegmentNumber",

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/quantitative_measurements.json
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/schema/quantitative_measurements.json
@@ -45,6 +45,12 @@
         "type": "STRING"
       },
       {
+        "description": "SeriesInstanceUID of the segmentation object defining the region of interest corresponding to the measurement.",
+        "mode": "NULLABLE",
+        "name": "segmentationSeriesUID",
+        "type": "STRING"
+      },
+      {
         "description": "SegmentNumber of the segment within the segmentation object referenced by segmentationInstanceUID defining the region of interest corresponding to the measurement.",
         "mode": "REPEATED",
         "name": "segmentationSegmentNumber",

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/measurement_groups.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/measurement_groups.sql
@@ -186,6 +186,7 @@ SELECT
   mWithFindingSite.findingSite,
   mWithSourceSeries.sourceSegmentedSeriesUID,
   mWithSegmentation.segmentationInstanceUID,
+  dicom_metadata.SeriesInstanceUID AS segmentationSeriesUID,
   mWithSegmentation.segmentationSegmentNumber,
   mWithID.contentSequence
 FROM
@@ -217,5 +218,9 @@ ON
   mWithID.SOPInstanceUID = mWithSegmentation.SOPInstanceUID
   AND mWithID.measurementGroup_number = mWithSegmentation.measurementGroup_number
   ---
+JOIN
+  `{project}.{dataset}.dicom_metadata` AS dicom_metadata
+ON
+  mWithSegmentation.segmentationInstanceUID = dicom_metadata.SOPInstanceUID
 ORDER BY
   trackingUniqueIdentifier

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/qualitative_measurements.sql
@@ -6,6 +6,7 @@ WITH
     SeriesInstanceUID,
     measurementGroup_number,
     segmentationInstanceUID,
+    segmentationSeriesUID,
     segmentationSegmentNumber,
     sourceSegmentedSeriesUID,
     trackingIdentifier,

--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/quantitative_measurements.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/quantitative_measurements.sql
@@ -8,6 +8,7 @@ WITH
 	  SeriesDescription,
     measurementGroup_number,
     segmentationInstanceUID,
+    segmentationSeriesUID,
     segmentationSegmentNumber,
     sourceSegmentedSeriesUID,
     trackingIdentifier,


### PR DESCRIPTION
SeriesInstanceUID is what is used by idc-index and OHIF, but until this PR, segmentation was referenced by SOPInstanceUID, requiring extra rather expensive join. Having access to segmentation SeriesInstanceUID should make keeping SOPInstanceUID unnecessary, saving time (and money).