### PR TITLE
BUG: v18 was used instead of {dataset}

### DIFF
--- a/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/dicom_metadata_curated_series_level.sql
+++ b/bq/generate_tables_and_views/derived_tables/BQ_Table_Building/derived_data_views/sql/dicom_metadata_curated_series_level.sql
@@ -30,7 +30,7 @@ SpecimenPreparationSequence_unnested AS (
         concept_code_sequence.CodeMeaning AS ccs_cm,
         concept_code_sequence.CodingSchemeDesignator AS ccs_csd,
         concept_code_sequence.CodeValue AS ccs_val,
-      FROM `bigquery-public-data.idc_v18.dicom_all`,
+      FROM `{project}.{dataset}.dicom_all`,
       UNNEST(SpecimenDescriptionSequence[SAFE_OFFSET(0)].SpecimenPreparationSequence) as preparation_unnest_step1,
       UNNEST(preparation_unnest_step1.SpecimenPreparationStepContentItemSequence) as preparation_unnest_step2,
       UNNEST(preparation_unnest_step2.ConceptNameCodeSequence) as concept_name_code_sequence,


### PR DESCRIPTION
@bcli4d this is very important - we need to update our public BQ after this. It's too bad this went unnoticed since v19!!!

Thank you @DanielaSchacherer!